### PR TITLE
Use options and drop scalaj-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ To perform latitude/longitude lookups simply provide a formatted address.
 
 ```scala
 // Lookup a location with a formatted address string
-val location = geo.lookup("2821 W 7th St, Fort Worth, TX")
+geo.lookup("2821 W 7th St, Fort Worth, TX") match {
+    case Some(location) => // do something...
+    case None => // Lookup produced no results
+}
 
 // If you need more granular control then the address object can be used
-val location = geo.lookup(
+val locationQuery = geo.lookup(
     Address("2821 W 7th St", "Fort Worth", "TX", None, None)
 )
 
@@ -50,9 +53,10 @@ Performing reverse lookups is just as easy.
 
 ```scala
 // Lookup an address by latitude/longitude
-val address = geo.reverseLookup(32.857, -96.748)
-
-println(address.toString)
+geo.reverseLookup(32.857, -96.748) match {
+    case Some(address) => println(address)
+    case None => println("Failed to find any addresses")
+}
 ```
 
 ### Other Related Projects

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ version := "1.0.0"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-    "org.scalaj" %% "scalaj-http" % "2.3.0",
     "com.owlike" % "genson" % "1.4",
     "com.owlike" % "genson-scala_2.11" % "1.4",
     "org.scalactic" %% "scalactic" % "3.0.1" % "test",

--- a/src/test/scala/com/github/mcross1882/geocoder/GeocoderSpec.scala
+++ b/src/test/scala/com/github/mcross1882/geocoder/GeocoderSpec.scala
@@ -8,14 +8,14 @@ class GeocoderSpec extends TestSpec {
     "A Geocoder" should "lookup a given address and convert it to a location entity" in {
         val location = geocoder.lookup(
             Address("2821 West 7th St.", "Dallas", "TX", Some("76107"), Some("US"))
-        )
+        ).get
 
         loseAccuracy(location.lat) should be(33)
         loseAccuracy(location.lng) should be(-97)
     }
 
     it should "lookup a string based address and convert it to a location entity" in {
-        val location = geocoder.lookup("2821 West 7th St., Dallas, TX 76107, US")
+        val location = geocoder.lookup("2821 West 7th St., Dallas, TX 76107, US").get
 
         loseAccuracy(location.lat) should be(33)
         loseAccuracy(location.lng) should be(-97)
@@ -24,7 +24,7 @@ class GeocoderSpec extends TestSpec {
     it should "lookup an address without a zip code" in {
         val location = geocoder.lookup(
             Address("2821 West 7th St.", "Dallas", "TX", None, Some("US"))
-        )
+        ).get
 
         loseAccuracy(location.lat) should be(33)
         loseAccuracy(location.lng) should be(-97)
@@ -33,7 +33,7 @@ class GeocoderSpec extends TestSpec {
     it should "lookup an address without a country" in {
         val location = geocoder.lookup(
             Address("2821 West 7th St.", "Dallas", "TX", Some("76107"), None)
-        )
+        ).get
 
         loseAccuracy(location.lat) should be(33)
         loseAccuracy(location.lng) should be(-97)
@@ -42,7 +42,7 @@ class GeocoderSpec extends TestSpec {
     it should "lookup an address without a zip code or country" in {
         val location = geocoder.lookup(
             Address("2821 West 7th St.", "Dallas", "TX", None, None)
-        )
+        ).get
 
         loseAccuracy(location.lat) should be(33)
         loseAccuracy(location.lng) should be(-97)
@@ -55,7 +55,7 @@ class GeocoderSpec extends TestSpec {
     }
 
     it should "reverse lookup a location and return an address entity" in {
-        val address = geocoder.reverseLookup(Location(32.7505842, -97.3574015))
+        val address = geocoder.reverseLookup(Location(32.7505842, -97.3574015)).get
 
         address.street should be("2821 W 7th St")
         address.city should be("Fort Worth")
@@ -65,7 +65,7 @@ class GeocoderSpec extends TestSpec {
     }
 
     it should "reverse lookup lat/lng values and return an address entity" in {
-        val address = geocoder.reverseLookup(32.7505842, -97.3574015)
+        val address = geocoder.reverseLookup(32.7505842, -97.3574015).get
 
         address.street should be("2821 W 7th St")
         address.city should be("Fort Worth")


### PR DESCRIPTION
This PR drops `scalaj-http` dependency in favor of java `URL` objects. It also switches the code to use options for handling missing or not found scenarios.