### PR TITLE
Fix response parsing and improve custom exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ easy to use geocoding functions that are thoroughly tested.
 
 ### Goals
 
-- No 3rd-party dependencies (`scala-xml` is required for projects building on `2.11.x`)
+- No 3rd-party dependencies (`scala-xml` is required for projects building on `2.11.x+`)
 - Fully unit tested
 - API Compliant
 - Easy to use and integrate
@@ -16,7 +16,7 @@ easy to use geocoding functions that are thoroughly tested.
 Include the following in your `build.sbt`
 
 ```
-libraryDependencies += "com.koddi" %% "geocoder" % "1.0.3"
+libraryDependencies += "com.koddi" %% "geocoder" % "1.1.0"
 ```
 
 And then import the classes into your code

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ easy to use geocoding functions that are thoroughly tested.
 Include the following in your `build.sbt`
 
 ```
-libraryDependencies += "com.koddi" %% "geocoder" % "1.0.2"
+libraryDependencies += "com.koddi" %% "geocoder" % "1.0.3"
 ```
 
 And then import the classes into your code

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "geocoder"
 
 organization := "com.koddi"
 
-version := "1.0.2"
+version := "1.0.3"
 
 scalaVersion := "2.11.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "geocoder"
 
 organization := "com.koddi"
 
-version := "1.0.3"
+version := "1.1.0"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/scala/com/koddi/geocoder/Exception.scala
+++ b/src/main/scala/com/koddi/geocoder/Exception.scala
@@ -8,20 +8,20 @@ package com.koddi.geocoder
 /**
  * Thrown when the response contains an invalid payload that cannot be parsed by the XML reader
  */
-class ResponseParsingException(e: Exception) extends Exception(e)
+case class ResponseParsingException(e: Exception) extends Exception(e)
 
 /**
  * Thrown when the API returns a generic error
  */
-class InvalidLocationException(message: String) extends Exception(message)
+case class FailedResponseException(status: String, message: String) extends Exception(message)
 
 /**
  * Thrown when the API returns INVALID_REQUEST status. Will contain the applicable error message.
  */
-class InvalidRequestException(message: String) extends Exception(message)
+case class InvalidRequestException(message: String) extends Exception(message)
 
 /**
  * Thrown when the API returns OVER_QUERY_LIMIT status. Will contain the applicable error message.
  */
-class OverQueryLimitException(message: String) extends Exception(message)
+case class OverQueryLimitException(message: String) extends Exception(message)
 

--- a/src/main/scala/com/koddi/geocoder/Exception.scala
+++ b/src/main/scala/com/koddi/geocoder/Exception.scala
@@ -5,7 +5,23 @@
   */
 package com.koddi.geocoder
 
+/**
+ * Thrown when the response contains an invalid payload that cannot be parsed by the XML reader
+ */
 class ResponseParsingException(e: Exception) extends Exception(e)
 
+/**
+ * Thrown when the API returns a generic error
+ */
 class InvalidLocationException(message: String) extends Exception(message)
+
+/**
+ * Thrown when the API returns INVALID_REQUEST status. Will contain the applicable error message.
+ */
+class InvalidRequestException(message: String) extends Exception(message)
+
+/**
+ * Thrown when the API returns OVER_QUERY_LIMIT status. Will contain the applicable error message.
+ */
+class OverQueryLimitException(message: String) extends Exception(message)
 

--- a/src/main/scala/com/koddi/geocoder/Geocoder.scala
+++ b/src/main/scala/com/koddi/geocoder/Geocoder.scala
@@ -130,7 +130,7 @@ class Geocoder(apiUrl: String, apiKey: Option[String], parameters: Option[Parame
             response.status match {
                 case Response.STATUS_OVER_QUERY_LIMIT => throw new OverQueryLimitException(message)
                 case Response.STATUS_INVALID_REQUEST  => throw new InvalidRequestException(message)
-                case _ => throw new InvalidLocationException(message)
+                case status => throw new FailedResponseException(status, message)
             }
         }
 

--- a/src/main/scala/com/koddi/geocoder/Geocoder.scala
+++ b/src/main/scala/com/koddi/geocoder/Geocoder.scala
@@ -126,7 +126,12 @@ class Geocoder(apiUrl: String, apiKey: Option[String], parameters: Option[Parame
                 case Some(error) => error
                 case None => s"${searchParam.capitalize} '${searchValue}' could not be geocoded."
             }
-            throw new InvalidLocationException(message)
+
+            response.status match {
+                case Response.STATUS_OVER_QUERY_LIMIT => throw new OverQueryLimitException(message)
+                case Response.STATUS_INVALID_REQUEST  => throw new InvalidRequestException(message)
+                case _ => throw new InvalidLocationException(message)
+            }
         }
 
         if (response.hasNoResults) {

--- a/src/main/scala/com/koddi/geocoder/Response.scala
+++ b/src/main/scala/com/koddi/geocoder/Response.scala
@@ -98,6 +98,14 @@ case class Result(
     partialMatch: Boolean,
     types: Seq[String])
 
+object Response {
+    val STATUS_OK = "OK"
+    val STATUS_FAILED = "FAILED"
+    val STATUS_ZERO_RESULTS = "ZERO_RESULTS"
+    val STATUS_OVER_QUERY_LIMIT = "OVER_QUERY_LIMIT"
+    val STATUS_INVALID_REQUEST = "INVALID_REQUEST"
+}
+
 /** The Google Maps response wrapper
  *
  * This entity represents the JSON response returned from
@@ -105,8 +113,10 @@ case class Result(
  */
 case class Response(status: String, results: Seq[Result], errorMessage: Option[String]) {
 
-    val success: Boolean = status == "OK" || status == "ZERO_RESULTS"
+    val success: Boolean = status == Response.STATUS_OK || status == Response.STATUS_ZERO_RESULTS
 
-    val hasNoResults: Boolean = status == "ZERO_RESULTS"
+    val hasNoResults: Boolean = status == Response.STATUS_ZERO_RESULTS
+
+    val isRateLimited: Boolean = status == Response.STATUS_OVER_QUERY_LIMIT
 }
 

--- a/src/main/scala/com/koddi/geocoder/ResponseParser.scala
+++ b/src/main/scala/com/koddi/geocoder/ResponseParser.scala
@@ -34,6 +34,8 @@ class ResponseParser {
 
     private def readResults(node: NodeSeq): Seq[Result] = {
         node.map{ result =>
+            val types = (result \ "type").map(_.text.trim).toSeq
+
             Result(
                 text(result, "place_id"),
                 text(result, "formatted_address"),
@@ -41,7 +43,7 @@ class ResponseParser {
                 readAddressComponents(result),
                 readPostcodeLocalities(result),
                 boolean(result, "partial_match"),
-                Seq(text(result, "type"))
+                types
             )
         }
     }

--- a/src/test/resources/api_response_invalid_request.xml
+++ b/src/test/resources/api_response_invalid_request.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GeocodeResponse>
+ <status>INVALID_REQUEST</status>
+ <error_message>Invalid request. Missing the 'address', 'bounds', 'components', 'latlng' or 'place_id' parameter.</error_message>
+ <results></results>
+</GeocodeResponse>
+

--- a/src/test/resources/api_response_multiple_result_types.xml
+++ b/src/test/resources/api_response_multiple_result_types.xml
@@ -1,0 +1,71 @@
+<GeocodeResponse>
+ <status>OK</status>
+ <result>
+  <type>street_address</type>
+  <type>point_of_interest</type>
+  <formatted_address>1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA</formatted_address>
+  <address_component>
+   <long_name>1600</long_name>
+   <short_name>1600</short_name>
+   <type>street_number</type>
+  </address_component>
+  <address_component>
+   <long_name>Amphitheatre Pkwy</long_name>
+   <short_name>Amphitheatre Pkwy</short_name>
+   <type>route</type>
+  </address_component>
+  <address_component>
+   <long_name>Mountain View</long_name>
+   <short_name>Mountain View</short_name>
+   <type>locality</type>
+   <type>political</type>
+  </address_component>
+  <address_component>
+   <long_name>San Jose</long_name>
+   <short_name>San Jose</short_name>
+   <type>administrative_area_level_3</type>
+   <type>political</type>
+  </address_component>
+  <address_component>
+   <long_name>Santa Clara</long_name>
+   <short_name>Santa Clara</short_name>
+   <type>administrative_area_level_2</type>
+   <type>political</type>
+  </address_component>
+  <address_component>
+   <long_name>California</long_name>
+   <short_name>CA</short_name>
+   <type>administrative_area_level_1</type>
+   <type>political</type>
+  </address_component>
+  <address_component>
+   <long_name>United States</long_name>
+   <short_name>US</short_name>
+   <type>country</type>
+   <type>political</type>
+  </address_component>
+  <address_component>
+   <long_name>94043</long_name>
+   <short_name>94043</short_name>
+   <type>postal_code</type>
+  </address_component>
+  <geometry>
+   <location>
+    <lat>37.4217550</lat>
+    <lng>-122.0846330</lng>
+   </location>
+   <location_type>ROOFTOP</location_type>
+   <viewport>
+    <southwest>
+     <lat>37.4188514</lat>
+     <lng>-122.0874526</lng>
+    </southwest>
+    <northeast>
+     <lat>37.4251466</lat>
+     <lng>-122.0811574</lng>
+    </northeast>
+   </viewport>
+  </geometry>
+  <place_id>ChIJ2eUgeAK6j4ARbn5u_wAGqWA</place_id>
+ </result>
+</GeocodeResponse>

--- a/src/test/resources/api_response_over_query_limit.xml
+++ b/src/test/resources/api_response_over_query_limit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GeocodeResponse>
+ <status>OVER_QUERY_LIMIT</status>
+ <error_message>You have exceeded your daily request quota for this API. We recommend registering for a key at the Google Developers Console: https://console.developers.google.com/apis/credentials?project=_</error_message>
+ <results></results>
+</GeocodeResponse>

--- a/src/test/scala/com/koddi/geocoder/GeocoderSpec.scala
+++ b/src/test/scala/com/koddi/geocoder/GeocoderSpec.scala
@@ -51,6 +51,20 @@ class GeocoderSpec extends TestSpec {
         }
     }
 
+    it should "throw an exception when an invalid request is sent" in {
+        val geocoder = new MockGeocoder("api_response_invalid_request.xml")
+        an [InvalidRequestException] should be thrownBy {
+            geocoder.lookup("abc ;; 123")
+        }
+    }
+
+    it should "throw an exception when the client has exceeded the rate limit" in {
+        val geocoder = new MockGeocoder("api_response_over_query_limit.xml")
+        an [OverQueryLimitException] should be thrownBy {
+            geocoder.lookup("abc ;; 123")
+        }
+    }
+
     private def loseAccuracy(value: Double): Long = Math.round(value)
 }
 

--- a/src/test/scala/com/koddi/geocoder/GeocoderSpec.scala
+++ b/src/test/scala/com/koddi/geocoder/GeocoderSpec.scala
@@ -46,8 +46,13 @@ class GeocoderSpec extends TestSpec {
 
     it should "throw an exception when an invalid lat/lng is given" in {
         val geocoder = new MockGeocoder("api_response_invalid.xml")
-        an [InvalidLocationException] should be thrownBy {
-            geocoder.lookup(-900d, -900d)
+        try {
+            geocoder.lookup(900, -900)
+        } catch {
+            case e: FailedResponseException => {
+                e.status should be("FAILED")
+            }
+            case e: Exception => fail()
         }
     }
 

--- a/src/test/scala/com/koddi/geocoder/ResponseParserSpec.scala
+++ b/src/test/scala/com/koddi/geocoder/ResponseParserSpec.scala
@@ -33,6 +33,26 @@ class ResponseParserSpec extends TestSpec {
         result.placeId should be("ChIJ2eUgeAK6j4ARbn5u_wAGqWA")
     }
 
+    it should "parse a valid Maps XML response with multiple result types" in {
+        val stream = getClass.getResourceAsStream("/api_response_multiple_result_types.xml")
+
+        val response = parser.parse(stream)
+        stream.close
+
+        response.status should be("OK")
+        response.results.length should be > 0
+
+        val result = response.results.head
+
+        result.types should be(Seq("street_address", "point_of_interest"))
+        result.addressComponents.head.longName should be("1600")
+        result.addressComponents.head.types should be (Seq("street_number"))
+        result.addressComponents(2).types should be (Seq("locality", "political"))
+        result.geometry.locationType should be("ROOFTOP")
+        result.geometry.viewport.southwest.latitude should be(37.4188514)
+        result.placeId should be("ChIJ2eUgeAK6j4ARbn5u_wAGqWA")
+    }
+
     it should "parse XML responses with postcode localities" in {
         val stream = getClass.getResourceAsStream("/api_response_with_postcodes.xml")
 


### PR DESCRIPTION
Fixes:
- the `Result` `type` property is now parsed as an array of strings versus a single string
- New custom exceptions were created for common statuses
  - `InvalidRequestException` thrown when an exception contains an invalid request payload
  - `OverQueryLimitException` thrown when the client hits the API quota/rate limit

BC Change:
- `InvalidLocationException` was renamed to `FailedResponseException` and now contains the `status` and `message` of the error.
- All custom exception classes were converted to `case classes` to expose their error messages publicly